### PR TITLE
Add a get_absolute_url() method

### DIFF
--- a/avatar/models.py
+++ b/avatar/models.py
@@ -26,7 +26,8 @@ from avatar.util import invalidate_cache
 from avatar.settings import (AVATAR_STORAGE_DIR, AVATAR_RESIZE_METHOD,
                              AVATAR_MAX_AVATARS_PER_USER, AVATAR_THUMB_FORMAT,
                              AVATAR_HASH_USERDIRNAMES, AVATAR_HASH_FILENAMES,
-                             AVATAR_THUMB_QUALITY, AUTO_GENERATE_AVATAR_SIZES)
+                             AVATAR_THUMB_QUALITY, AUTO_GENERATE_AVATAR_SIZES,
+                             AVATAR_DEFAULT_SIZE)
 
 
 def avatar_file_path(instance=None, filename=None, size=None, ext=None):
@@ -123,6 +124,9 @@ class Avatar(models.Model):
 
     def avatar_url(self, size):
         return self.avatar.storage.url(self.avatar_name(size))
+        
+    def get_absolute_url(self):
+        return self.avatar_url(AVATAR_DEFAULT_SIZE)
     
     def avatar_name(self, size):
         ext = find_extension(AVATAR_THUMB_FORMAT)


### PR DESCRIPTION
A get_absolute_url() method would be nice to help implementers if they want to use it in notification templates for instance. It needs to exists for projects to overwrite it, so here is a basic default.
