### PR TITLE
Adding support for Django 1.4 messaging

### DIFF
--- a/avatar/views.py
+++ b/avatar/views.py
@@ -3,6 +3,7 @@ from django.shortcuts import render_to_response
 from django.template import RequestContext
 from django.utils.translation import ugettext as _
 from django.conf import settings
+from django.contrib import messages # jfm needed for update to django1.4
 
 from django.contrib.auth.decorators import login_required
 
@@ -68,8 +69,8 @@ def add(request, extra_context=None, next_override=None,
             image_file = request.FILES['avatar']
             avatar.avatar.save(image_file.name, image_file)
             avatar.save()
-            request.user.message_set.create(
-                message=_("Successfully uploaded a new avatar."))
+            messages.add_message(request, messages.SUCCESS,
+                "Successfully uploaded a new avatar.")
             avatar_updated.send(sender=Avatar, user=request.user, avatar=avatar)
             return HttpResponseRedirect(next_override or _get_next(request))
     return render_to_response(
@@ -106,8 +107,8 @@ def change(request, extra_context=None, next_override=None,
             avatar.primary = True
             avatar.save()
             updated = True
-            request.user.message_set.create(
-                message=_("Successfully updated your avatar."))
+            messages.add_message(request, messages.SUCCESS,
+                "Successfully updated your avatar.")
         if updated:
             avatar_updated.send(sender=Avatar, user=request.user, avatar=avatar)
         return HttpResponseRedirect(next_override or _get_next(request))
@@ -143,8 +144,8 @@ def delete(request, extra_context=None, next_override=None, *args, **kwargs):
                         avatar_updated.send(sender=Avatar, user=request.user, avatar=avatar)
                         break
             Avatar.objects.filter(id__in=ids).delete()
-            request.user.message_set.create(
-                message=_("Successfully deleted the requested avatars."))
+            messages.add_message(request, messages.SUCCESS,
+                "Successfully deleted the requested avatars.")
             return HttpResponseRedirect(next_override or _get_next(request))
     return render_to_response(
         'avatar/confirm_delete.html',


### PR DESCRIPTION
Changed a couple of lines related to the newer style messaging.

Based on [this section](https://docs.djangoproject.com/en/dev/ref/contrib/messages/#using-messages-in-views-and-templates) of the docs.
