### PR TITLE
Django 1.6 compatibility fixes

### DIFF
--- a/avatar/urls.py
+++ b/avatar/urls.py
@@ -1,4 +1,8 @@
-from django.conf.urls.defaults import patterns, url
+try:
+    from django.conf.urls import patterns, url
+except ImportError:
+    # Django < 1.4
+    from django.conf.urls.defaults import patterns, url
 
 urlpatterns = patterns(
     'avatar.views',

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,4 +1,8 @@
-from django.conf.urls.defaults import patterns, include, handler500, handler404
+try:
+    from django.conf.urls import patterns, include, handler500, handler404
+except ImportError:
+    # Django < 1.4
+    from django.conf.urls.defaults import patterns, include, handler500, handler404
  
 DEFAULT_CHARSET = 'utf-8'
  


### PR DESCRIPTION
`django.conf.urls.defaults` has been deprecated and fully removed in Django 1.6 release series.

Reference:

`django.conf.urls.defaults will be removed. The functions include(), patterns() and url() plus handler404, handler500, are now available through django.conf.urls .`

https://docs.djangoproject.com/en/dev/internals/deprecation/
