### PR TITLE
fix admin detail too slow when there is large number of users

### DIFF
--- a/avatar/admin.py
+++ b/avatar/admin.py
@@ -10,6 +10,7 @@ from avatar.utils import get_user_model
 class AvatarAdmin(admin.ModelAdmin):
     list_display = ("get_avatar", "user", "primary", "date_uploaded")
     list_filter = ("primary",)
+    autocomplete_fields = ("user",)
     search_fields = (
         "user__%s" % getattr(get_user_model(), "USERNAME_FIELD", "username"),
     )


### PR DESCRIPTION
Admin detail is not loading at all (it is so slow, that it could take hours) if there is large number of users. This fixes that problem.