### PR TITLE
Pillow 10 compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,9 +6,12 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11']
-        django-version: ['3.2', '4.0', '4.1']
+        django-version: ['3.2', '4.1', '4.2']
         include:
           - python-version: 3.7
+            django-version: 3.2
+        exclude:
+          - python-version: 3.11
             django-version: 3.2
       fail-fast: false
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,8 @@
 Changelog
 =========
+* Unreleased
+    * Use ``Image.Resampling.LANCZOS`` instead of ``Image.LANCZOS`` that was removed in Pillow 10.0.0
+
 * 7.1.1 (February 23, 2023)
     * Switch to setuptools for building
 

--- a/avatar/admin.py
+++ b/avatar/admin.py
@@ -17,14 +17,12 @@ class AvatarAdmin(admin.ModelAdmin):
     list_per_page = 50
 
     def get_avatar(self, avatar_in):
-        context = dict(
-            {
+        context = {
                 "user": avatar_in.user,
                 "url": avatar_in.avatar.url,
                 "alt": str(avatar_in.user),
                 "size": 80,
-            }
-        )
+        }
         return render_to_string("avatar/avatar_tag.html", context)
 
     get_avatar.short_description = _("Avatar")

--- a/avatar/admin.py
+++ b/avatar/admin.py
@@ -18,10 +18,10 @@ class AvatarAdmin(admin.ModelAdmin):
 
     def get_avatar(self, avatar_in):
         context = {
-                "user": avatar_in.user,
-                "url": avatar_in.avatar.url,
-                "alt": str(avatar_in.user),
-                "size": 80,
+            "user": avatar_in.user,
+            "url": avatar_in.avatar.url,
+            "alt": str(avatar_in.user),
+            "size": 80,
         }
         return render_to_string("avatar/avatar_tag.html", context)
 

--- a/avatar/conf.py
+++ b/avatar/conf.py
@@ -5,7 +5,7 @@ from PIL import Image
 
 class AvatarConf(AppConf):
     DEFAULT_SIZE = 80
-    RESIZE_METHOD = Image.LANCZOS
+    RESIZE_METHOD = Image.Resampling.LANCZOS
     STORAGE_DIR = "avatars"
     PATH_HANDLER = "avatar.models.avatar_path_handler"
     GRAVATAR_BASE_URL = "https://www.gravatar.com/avatar/"

--- a/docs/index.txt
+++ b/docs/index.txt
@@ -211,7 +211,7 @@ appear on the site. Listed below are those settings:
 .. py:data:: AVATAR_RESIZE_METHOD
 
     The method to use when resizing images, based on the options available in
-    Pillow. Defaults to ``Image.LANCZOS``.
+    Pillow. Defaults to ``Image.Resampling.LANCZOS``.
 
 .. py:data:: AVATAR_STORAGE_DIR
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,14 +19,15 @@ classifiers=[
         "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.0",
         "Framework :: Django :: 4.1",
+        "Framework :: Django :: 4.2",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ]
 dynamic = ["version", "dependencies"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers=[
         "Intended Audience :: Developers",
         "Framework :: Django",
         "Framework :: Django :: 3.2",
-        "Framework :: Django :: 4.0",
         "Framework :: Django :: 4.1",
         "Framework :: Django :: 4.2",
         "License :: OSI Approved :: BSD License",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Pillow>=8.4.0
+Pillow>=9.3.0
 django-appconf>=1.0.5
 dnspython>=2.3.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
-coverage==7.1.0
+coverage~=7.1.0
 django
 python-magic


### PR DESCRIPTION
Pillow 10.0.0 came out recently and drops `Image.LANCZOS` as a symbol (was deprecated in 9?). The new symbol is `Image.Resampling.LANCZOS`

Also update Python and Django versions in `pyproject.toml` and `test.yml`