### PR TITLE
Update models.py

### DIFF
--- a/avatar/models.py
+++ b/avatar/models.py
@@ -5,7 +5,6 @@ from io import BytesIO
 
 from django.core.files import File
 from django.core.files.base import ContentFile
-from django.core.files.storage import storages
 from django.db import models
 from django.db.models import signals
 from django.utils.encoding import force_bytes, force_str

--- a/avatar/models.py
+++ b/avatar/models.py
@@ -21,12 +21,12 @@ try:
     # of the deprecated django.core.files.storage.get_storage_class
     from django.core.files.storage import storages
 
-    avatar_storage = storages["staticfiles"].__class__
+    avatar_storage = storages[settings.AVATAR_STORAGE].__class__
 except ImportError:
     # Backwards compatibility for Django versions prior to 4.2
     from django.core.files.storage import get_storage_class
 
-    avatar_storage = get_storage_class(settings.STATICFILES_STORAGE)
+    avatar_storage = get_storage_class(settings.AVATAR_STORAGE)
 
 
 def avatar_path_handler(

--- a/avatar/models.py
+++ b/avatar/models.py
@@ -5,7 +5,7 @@ from io import BytesIO
 
 from django.core.files import File
 from django.core.files.base import ContentFile
-from django.core.files.storage import get_storage_class
+from django.core.files.storage import storages
 from django.db import models
 from django.db.models import signals
 from django.utils.encoding import force_bytes, force_str
@@ -17,7 +17,18 @@ from PIL import Image, ImageOps
 from avatar.conf import settings
 from avatar.utils import get_username, invalidate_cache
 
-avatar_storage = get_storage_class(settings.AVATAR_STORAGE)()
+
+try:
+    # From Django 4.2 use django.core.files.storage.storages in favor
+    # of the deprecated django.core.files.storage.get_storage_class
+    from django.core.files.storage import storages
+
+    avatar_storage = storages["staticfiles"].__class__
+except ImportError:
+    # Backwards compatibility for Django versions prior to 4.2
+    from django.core.files.storage import get_storage_class
+
+    avatar_storage = get_storage_class(settings.STATICFILES_STORAGE)
 
 
 def avatar_path_handler(


### PR DESCRIPTION
Django 4.2 deprecated `get_storage_class`. Publishing a change to source storage from `from django.core.files.storage import storages`

[Reference](https://docs.djangoproject.com/en/4.2/ref/files/storage/#django.core.files.storage.storages)