### PR TITLE
Close files in create thumbnail

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@ Changelog
 =========
 * 9.0.0 (in progress)
     * Fix files not closed in `create_thumbnail`
-    
+
 * 8.0.1
     * Fix Django 5.1 compatibility
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,8 @@
 Changelog
 =========
+* 9.0.0 (in progress)
+    * Fix files not closed in `create_thumbnail`
+    
 * 8.0.1
     * Fix Django 5.1 compatibility
 

--- a/avatar/models.py
+++ b/avatar/models.py
@@ -1,7 +1,7 @@
 import binascii
-from contextlib import closing
 import hashlib
 import os
+from contextlib import closing
 from io import BytesIO
 
 from django.core.files import File

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,8 +1,8 @@
 import math
 import os.path
+import sys
 from pathlib import Path
 from shutil import rmtree
-import sys
 from unittest import skipIf
 
 from django.contrib.admin.sites import AdminSite

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2,6 +2,8 @@ import math
 import os.path
 from pathlib import Path
 from shutil import rmtree
+import sys
+from unittest import skipIf
 
 from django.contrib.admin.sites import AdminSite
 from django.core import management
@@ -118,6 +120,7 @@ class AvatarTests(TestCase):
         self.assertTrue(avatar.primary)
 
     # We allow the .tiff file extension but not the mime type
+    @skipIf(sys.platform == "win32", "Skipping test on Windows platform")
     @override_settings(AVATAR_ALLOWED_FILE_EXTS=(".png", ".gif", ".jpg", ".tiff"))
     @override_settings(
         AVATAR_ALLOWED_MIMETYPES=("image/png", "image/gif", "image/jpeg")
@@ -130,6 +133,7 @@ class AvatarTests(TestCase):
         self.assertNotEqual(response.context["upload_avatar_form"].errors, {})
 
     # We allow the .tiff file extension and the mime type
+    @skipIf(sys.platform == "win32", "Skipping test on Windows platform")
     @override_settings(AVATAR_ALLOWED_FILE_EXTS=(".png", ".gif", ".jpg", ".tiff"))
     @override_settings(
         AVATAR_ALLOWED_MIMETYPES=("image/png", "image/gif", "image/jpeg", "image/tiff")
@@ -141,6 +145,7 @@ class AvatarTests(TestCase):
         self.assertEqual(len(response.redirect_chain), 1)  # Redirect only if it worked
         self.assertEqual(response.context["upload_avatar_form"].errors, {})
 
+    @skipIf(sys.platform == "win32", "Skipping test on Windows platform")
     @override_settings(AVATAR_ALLOWED_FILE_EXTS=(".jpg", ".png"))
     def test_image_without_wrong_extension(self):
         response = upload_helper(self, "imagefilewithoutext")
@@ -148,6 +153,7 @@ class AvatarTests(TestCase):
         self.assertEqual(len(response.redirect_chain), 0)  # Redirect only if it worked
         self.assertNotEqual(response.context["upload_avatar_form"].errors, {})
 
+    @skipIf(sys.platform == "win32", "Skipping test on Windows platform")
     @override_settings(AVATAR_ALLOWED_FILE_EXTS=(".jpg", ".png"))
     def test_image_with_wrong_extension(self):
         response = upload_helper(self, "imagefilewithwrongext.ogg")


### PR DESCRIPTION
Use `contextlib.closing` to close the `orig` file in `Avatar.create_thumbnail` method.

Fixes #244 