### PR TITLE
Fix FileNotFoundError when deleting avatar with absent resized/ dir

### DIFF
--- a/avatar/models.py
+++ b/avatar/models.py
@@ -210,7 +210,10 @@ def remove_avatar_images(instance=None, delete_main_avatar=True, **kwargs):
     path, filename = os.path.split(base_filepath)
     # iterate through resized avatars directories and delete resized avatars
     resized_path = os.path.join(path, "resized")
-    resized_widths, _ = instance.avatar.storage.listdir(resized_path)
+    try:
+        resized_widths, _ = instance.avatar.storage.listdir(resized_path)
+    except FileNotFoundError:
+        resized_widths = []
     for width in resized_widths:
         resized_width_path = os.path.join(resized_path, width)
         resized_heights, _ = instance.avatar.storage.listdir(resized_width_path)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -50,14 +50,11 @@ SITE_ID = 1
 
 SECRET_KEY = "something-something"
 
-ROOT_URLCONF = "tests.urls"
-
 STATIC_URL = "/site_media/static/"
 
 AVATAR_ALLOWED_FILE_EXTS = (".jpg", ".png")
 AVATAR_MAX_SIZE = 1024 * 1024
 AVATAR_MAX_AVATARS_PER_USER = 20
 AVATAR_AUTO_GENERATE_SIZES = [51, 62, (33, 22), 80]
-
 
 MEDIA_ROOT = os.path.join(SETTINGS_DIR, "../test-media")

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -217,6 +217,19 @@ class AvatarTests(TestCase):
         self.assertEqual(receiver.sender, Avatar)
         self.assertEqual(receiver.signal_sent_count, 1)
 
+    def test_delete_avatar_without_resized_directory(self):
+        self.test_normal_image_upload()
+        avatar = Avatar.objects.get(user=self.user)
+        resized_path = os.path.join(
+            self.testmediapath,
+            os.path.dirname(avatar.avatar.name),
+            "resized",
+        )
+        if os.path.exists(resized_path):
+            rmtree(resized_path)
+        avatar.delete()
+        self.assertEqual(Avatar.objects.filter(user=self.user).count(), 0)
+
     def test_delete_primary_avatar_and_new_primary(self):
         self.test_there_can_be_only_one_primary_avatar()
         primary = get_primary_avatar(self.user)


### PR DESCRIPTION
Thank you for this application.

When deleting an `Avatar` instance (e.g. via the REST API), a `FileNotFoundError` is raised if the `resized/` sub-directory for that avatar has never been created (or was cleaned up externally). Catching the issue makes the code more robust.

You may decide to opt for another methodology.

## Steps to reproduce

1. Enable `AVATAR_CLEANUP_DELETED = True` (the default).
2. Create an `Avatar` record whose `resized/` thumbnail directory does not exist on
   disk (e.g. thumbnails were never generated, or the directory was removed).
3. Call `avatar.delete()` (as the REST API's `destroy` action does).

## Traceback

```python
File "…/avatar/models.py", line 213, in remove_avatar_images
    resized_widths, _ = instance.avatar.storage.listdir(resized_path)
  File "…/django/core/files/storage/filesystem.py", line 187, in listdir
    with os.scandir(path) as entries:
FileNotFoundError: [Errno 2] No such file or directory: '…/avatars/<myuser>/resized'
```

## Note

* The bug is only triggered by `instance.delete()` (used by the REST API I just enabled on my app).
* The `QuerySet.delete()` (used by the web views I disabled on my website) does not exhibit it.
